### PR TITLE
bincheck tweaks.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,8 @@
-v2.0.2
+# WARNING: make sure to use the correct release-X.Y branch.
+# The version can take one of two formats:
+# - v<version>: release binary from https://binaries.cockroachdb.com
+#   eg: v2.0.2
+# - test:v<version>: test release binary from https://binaries-test.cockroachdb.com
+#   eg: test:vx.y.z[-extensions]
+#
+v2.1.0-alpha.20180604

--- a/bincheck
+++ b/bincheck
@@ -13,10 +13,19 @@ readonly cockroach="$1"
 readonly version="$2"
 readonly urlfile=cockroach-url
 
+# Display build information.
+"$cockroach" version
+
 # Start a CockroachDB server, wait for it to become ready, and arrange for it to
 # be force-killed when the script exits.
 rm -f "$urlfile"
+
+# Generate encryption key.
+#"$cockroach" gen encryption-key aes-128.key
+
+# Start node with encryption enabled.
 "$cockroach" start --insecure --listening-url-file="$urlfile" &
+#"$cockroach" start --insecure --listening-url-file="$urlfile" --enterprise-encryption=path=cockroach-data,key=aes-128.key,old-key=plain &
 trap "kill -9 $! &> /dev/null" EXIT
 for i in {0..3}
 do

--- a/download_binary.sh
+++ b/download_binary.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+binary_suffix=$1
+binary_source=""
+cockroach_version=""
+while read line; do
+  case "$line" in
+  \#*)
+    continue ;;
+  test:*)
+    binary_source="https://binaries-test.cockroachdb.com"
+    parts=(${line//:/ })
+    cockroach_version="${parts[1]}"
+    ;;
+  "")
+    continue
+    ;;
+  *)
+    binary_source="https://binaries.cockroachdb.com"
+    cockroach_version="${line}"
+    ;;
+  esac
+done < VERSION
+
+export COCKROACH_VERSION="${cockroach_version}"
+binary_url="${binary_source}/cockroach-${cockroach_version}.${binary_suffix}"
+
+mkdir -p mnt
+
+# Check if this is a tarball or zip.
+if [[ "${binary_suffix}" == *.tgz ]]; then
+  curl -sSfL "${binary_url}" | tar zx -C mnt --strip-components=1
+else
+  curl -sSfL "${binary_url}" > cockroach.zip
+  7z e -omnt cockroach.zip
+fi
+
+echo "Downloaded ${binary_url}"

--- a/test-linux
+++ b/test-linux
@@ -2,15 +2,14 @@
 
 set -euo pipefail
 
+# Download the binary based on the VERSION file. This sets the COCKROACH_VERSION env variable
+# and downloads the binary in ./mnt/
+. download_binary.sh "linux-amd64.tgz"
+
 ssh() {
   command ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     root@localhost -p 2222 "$@"
 }
-
-mkdir -p mnt
-
-curl -L https://binaries.cockroachdb.com/cockroach-$(<VERSION).linux-amd64.tgz \
-  | tar zx -C mnt --strip-components=1
 
 qemu-system-x86_64 \
   -cpu qemu64,-sse4.2 \
@@ -30,4 +29,4 @@ do
   sleep $backoff
 done
 
-ssh /bin/bash -s /bincheck/cockroach $(<VERSION) < bincheck
+ssh /bin/bash -s /bincheck/cockroach ${COCKROACH_VERSION} < bincheck

--- a/test-macos
+++ b/test-macos
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-curl -sSfL https://binaries.cockroachdb.com/cockroach-$(<VERSION).darwin-10.9-amd64.tgz \
-  | tar zx --strip-components=1
+# Download the binary based on the VERSION file. This sets the COCKROACH_VERSION env variable
+# and downloads the binary in ./mnt/
+. download_binary.sh "darwin-10.9-amd64.tgz"
 
-./bincheck ./cockroach $(<VERSION)
+./bincheck ./mnt/cockroach ${COCKROACH_VERSION}

--- a/test-windows
+++ b/test-windows
@@ -2,10 +2,8 @@
 
 set -euo pipefail
 
-base=cockroach-$(<VERSION).windows-6.2-amd64
+# Download the binary based on the VERSION file. This sets the COCKROACH_VERSION env variable
+# and downloads the binary in ./mnt/
+. download_binary.sh "windows-6.2-amd64.zip"
 
-curl -sSfL "https://binaries.cockroachdb.com/$base.zip" > cockroach.zip
-7z e cockroach.zip
-
-
-./bincheck ./cockroach.exe $(<VERSION)
+./bincheck ./mnt/cockroach.exe ${COCKROACH_VERSION}


### PR DESCRIPTION
I created a release-2.0 branch from master before this change.

* run `cockroach version` to make CI outputs clearer
* add ability to run against test release builds (`test:` prefix in
VERSION)
* example for encryption (disabled for now, no builds have the gen
command)