### PR TITLE
update 19.2 branch with 19.2.3 sha

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -13,5 +13,5 @@
 #
 # Be sure to list the expected SHA, in full, on the line following the version.
 
-v19.2.2
-3cbd05602d4aeaebbccea18d66ad0fdf8db482a5
+v19.2.3
+2353f82b598b216a594ed7e6fc2eca66fe9d75e7


### PR DESCRIPTION
i believe this is something that was accidentally done on master instead of the release-19.2 branch
https://github.com/cockroachdb/bincheck/pull/167/files