### PR TITLE
Remove explicit ulimit adjustment for macOS

### DIFF
--- a/test-macos
+++ b/test-macos
@@ -2,17 +2,6 @@
 
 set -euo pipefail
 
-# Temporary workaround for an issue introduced in #37705. From a discussion in
-# the #release channel:
-#
-# ok, so that means pr 37705 was incomplete. i think it's trying to set the
-# limit too high, it fails once, then it falls back to the default. it should
-# probably make two attempts: set it to the recommended level, and if that fails
-# and we're still below the minimum, try one more time to set it to the minimum
-#
-# We should make the above update in crdb and then remove this line.
-ulimit -n 2048
-
 # Download the binary based on the VERSION file. This sets the COCKROACH_VERSION env variable
 # and downloads the binary in ./mnt/
 . download_binary.sh "darwin-10.9-amd64.tgz"


### PR DESCRIPTION
It is useful to test that CockroachDB is correctly adjusting ulimits. The issue
described in the removed comment was resolved by cockroachdb/cockroach#38472.