### PR TITLE
Use start-single-node; don't pipe into tar

### DIFF
--- a/bincheck
+++ b/bincheck
@@ -31,7 +31,7 @@ echo "Generating encryption key:"
 echo ""
 
 # Start node with encryption enabled.
-"$cockroach" start --insecure --listening-url-file="$urlfile" --enterprise-encryption=path=cockroach-data,key=aes-128.key,old-key=plain &
+"$cockroach" start-single-node --insecure --listening-url-file="$urlfile" --enterprise-encryption=path=cockroach-data,key=aes-128.key,old-key=plain &
 
 trap "kill -9 $! &> /dev/null" EXIT
 for i in {0..3}

--- a/download_binary.sh
+++ b/download_binary.sh
@@ -28,7 +28,8 @@ mkdir -p mnt
 
 # Check if this is a tarball or zip.
 if [[ "${binary_suffix}" == *.tgz ]]; then
-  curl -sSfL "${binary_url}" | tar zx -C mnt --strip-components=1
+  curl -sSfL "${binary_url}" > cockroach.tar.gz
+  tar zxf cockroach.tar.gz -C mnt --strip-components=1
 else
   curl -sSfL "${binary_url}" > cockroach.zip
   7z e -omnt cockroach.zip


### PR DESCRIPTION
#### Use start-single-node

Using just `start` for a single node cluster no longer works on `master`.

#### Don't pipe into tar

Update `download_binary.sh` to not pipe curl into tar (which apparently can
result in spurious "failed writing body" errors from curl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/bincheck/215)
<!-- Reviewable:end -->
