### PR TITLE
Enable GitHub Actions for release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: bincheck
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release-* ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release-* ]
 
 jobs:
 


### PR DESCRIPTION
This enables GitHub Actions on the release branches in order to check
PRs against non-master branches.